### PR TITLE
2n5q3hc-replace-span-with-strong

### DIFF
--- a/src/docs/components/badges.hbs
+++ b/src/docs/components/badges.hbs
@@ -9,9 +9,9 @@
   <div class="container mt-4">
     <h1>Badges</h1>
     <div class=" d-flex flex-column align-items-start">
-      <span class="badge badge-purple mb-1 mt-1">Tan</span>
-      <span class="badge badge-secondary mb-1 mt-1">Hair</span>
-      <span class="badge badge-blue mb-1 mt-1">Body</span>
+      <strong class="badge badge-purple mb-1 mt-1">Tan</strong>
+      <strong class="badge badge-secondary mb-1 mt-1">Hair</strong>
+      <strong class="badge badge-blue mb-1 mt-1">Body</strong>
     </div>
     <p class="my-4">Circle Badge with svg</p>
     <div class="row">

--- a/src/docs/compounds/result-card.hbs
+++ b/src/docs/compounds/result-card.hbs
@@ -18,7 +18,7 @@
         <div class="p-2 bg-white h-100">
           <p class="d-flex justify-content-between align-items-center mb-0">
             <img class="svg text-primary h4 mb-0" src="icons/five-stars.svg" replace-to-svg />
-            <span class="badge badge-blue mb-1 mt-1">Body</span>
+            <strong class="badge badge-blue mb-1 mt-1">Body</strong>
           </p>
           <p>
             <strong>Product:&nbsp;</strong>

--- a/src/partials/components/result-card-carousel.hbs
+++ b/src/partials/components/result-card-carousel.hbs
@@ -7,7 +7,7 @@
   <div class="p-2 bg-white h-100">
     <p class="d-flex justify-content-between align-items-center mb-0">
       <img class="svg text-primary h4 mb-0" src="icons/five-stars.svg" replace-to-svg />
-      <span class="badge {{badge_color}} mb-1 mt-1">{{badge}}</span>
+      <strong class="badge {{badge_color}} mb-1 mt-1">{{badge}}</strong>
     </p>
     <p>
       <strong>Product:&nbsp;</strong>

--- a/src/partials/compounds/upsell-blog.hbs
+++ b/src/partials/compounds/upsell-blog.hbs
@@ -5,7 +5,7 @@
 			<img src="https://via.placeholder.com/150x208.jpg/EFADBA" class="w-100" />
 		</picture>
 		<figcaption class="d-flex flex-column">
-			<span class="upsell__title">That’s a wrap bundle</span>
+			<strong class="upsell__title">That’s a wrap bundle</strong>
 			<span class="upsell__price text-primary flex-grow-1">
 				<span class="compare">£XX.XX</span>
 				£XX.XX

--- a/src/partials/compounds/upsell-pdp.hbs
+++ b/src/partials/compounds/upsell-pdp.hbs
@@ -5,11 +5,11 @@
 			<img src="https://via.placeholder.com/130x159.jpg/EFADBA" class="w-auto" />
 		</picture>
 		<figcaption class="d-flex flex-column mx-0 pl-g pl-lg-2 justify-content-around justify-content-lg-between py-0 font-size-base">
-			<span class="mt-0 mb-25 font-weight-bold">That’s A Wrap Bundle</span>
+			<strong class="mt-0 mb-25">That’s A Wrap Bundle</strong>
 			<p class="mb-25">Like A Virgin Coconut Hair Masque, Two-tiered Tangle Tamer.</p>
 			<span class="mb-25 text-primary">
 				<span class="text-linethrough text-body mr-25 text-nowrap">£139.90</span>
-				<span class="font-weight-bold mr-25 text-nowrap">£129.90</span>
+				<strong class="mr-25 text-nowrap">£129.90</strong>
 			</span>
 			<div class="d-flex flex-shrink-0">
 				<button type="submit" class="btn btn-outline-primary">Add to cart</button>


### PR DESCRIPTION
FIXES:
- Use semantic markup like strong instead of using the CSS font- weight property.

NOTES:
Since  we're loading bootstrap from node modules, and with vars , it's only possible to change : $badge-font-weight , other than overwriting, which would eliminate the purpuse.